### PR TITLE
Add a check for the MSIE user agent

### DIFF
--- a/checkIEVersion.js
+++ b/checkIEVersion.js
@@ -12,10 +12,14 @@ $(document).ready({
 
 	  if (index > 0) {
 	    // return IE version
-	    return parseInt(agent.substring(index+ 5, agent.indexOf(".", index)));
+	    return parseInt(agent.substring(index + 5, agent.indexOf(".", index)));
 	  } else if (agent.indexOf("Trident/7.0") > 0) {
 	    //IE11 wants to trick user agent parsers
 	    return 11;
+	  } else if(agent.indexOf("Edge/")) {
+	  	//return Edge version
+	  	var index = agent.indexOf("Edge/");
+		return parseInt(agent.substring(index + 5, agent.indexOf(".", index)));
 	  } else {
 	    //no IE
 	    return 0;

--- a/checkIEVersion.js
+++ b/checkIEVersion.js
@@ -16,7 +16,7 @@ $(document).ready({
 	  } else if (agent.indexOf("Trident/7.0") > 0) {
 	    //IE11 wants to trick user agent parsers
 	    return 11;
-	  } else if(agent.indexOf("Edge/")) {
+	  } else if(agent.indexOf("Edge/") > 0) {
 	  	//return Edge version
 	  	var index = agent.indexOf("Edge/");
 		return parseInt(agent.substring(index + 5, agent.indexOf(".", index)));

--- a/checkIEVersion.js
+++ b/checkIEVersion.js
@@ -13,7 +13,7 @@ $(document).ready({
 	  if (index > 0) {
 	    // return IE version
 	    return parseInt(agent.substring(index+ 5, agent.indexOf(".", index)));
-	  } else if (!navigator.userAgent.match(/Trident\/7\./)) {
+	  } else if (agent.indexOf("Trident/7.0") > 0) {
 	    //IE11 wants to trick user agent parsers
 	    return 11;
 	  } else {

--- a/checkIEVersion.js
+++ b/checkIEVersion.js
@@ -1,0 +1,25 @@
+/**
+* @name checkIEVersion
+* @author chrisonntag
+* @desc checks if a user uses MSIE 
+*/
+
+$(document).ready({
+
+	function checkIEVersion() {
+	  var agent = window.navigator.userAgent;
+	  var index = agent.indexOf("MSIE");
+
+	  if (index > 0) {
+	    // return IE version
+	    return parseInt(agent.substring(index+ 5, agent.indexOf(".", index)));
+	  } else if (!navigator.userAgent.match(/Trident\/7\./)) {
+	    //IE11 wants to trick user agent parsers
+	    return 11;
+	  } else {
+	    //no IE
+	    return 0;
+	  }
+	}
+
+});


### PR DESCRIPTION
This PR adds a function which checks if the used browser is MSIE and returns its version number. It also checks for Microsofts try to fool user agent parsers in Internet Explorer 11.
